### PR TITLE
introduce state to simulate arbitrary code jumps

### DIFF
--- a/pm.py
+++ b/pm.py
@@ -9,13 +9,18 @@ from sympy import nextprime
 
 
 class ProgramMachine:
-    def __init__(self, registers):
+    def __init__(self, registers, initial_state=None):
         self.counters = [0] * registers
+        # Hold a concept of 'state' to simulate arbitrary instruction jumps
+        # as in Minsky's original description, but not present in PMMN.
+        self.state = initial_state
 
     def inc(self, counter):
         self.counters[counter] += 1
 
-    def dec(self, counter):
+    def dec(self, counter, state=None):
+        if state and state != self.state:
+            return False
         test = bool(self.counters[counter])
         if test:
             self.counters[counter] -= 1
@@ -25,7 +30,9 @@ class ProgramMachine:
     def inc_by(self, counter, amount):
         self.counters[counter] += amount
 
-    def dec_by(self, counter, amount):
+    def dec_by(self, counter, amount, state=None):
+        if state and state != self.state:
+            return False
         test = bool(self.counters[counter])
         self.counters[counter] = max(0, self.counters[counter] - amount)
         return test

--- a/tests/test_2reg_state.py
+++ b/tests/test_2reg_state.py
@@ -18,7 +18,7 @@ def view_debug(m):
 
 def test_state_vreg_duplicate():
     # x 0 0 ->  0 x x
-    m = ProgramMachine(2)
+    m = ProgramMachine(2, 'COPY')
     x = 4
     r = 2**x
     # set v.reg.2 to x
@@ -28,9 +28,8 @@ def test_state_vreg_duplicate():
     m.inc(1); m.dec(1)
     print('Start:')
     m.show()
-    state = 'COPY'
 
-    while state == 'COPY' and m.dec(0):
+    while m.dec(0, 'COPY'):
         print(f'OUTER LOOP: R0: {prime_decode(m.counters[0])} -- {m.counters[0]}')
         m.inc(0)
         while m.dec(0):
@@ -38,7 +37,7 @@ def test_state_vreg_duplicate():
                 m.inc_by(1, 15)
             else:
                 print('-------Zeroed early!--------')
-                state = 'DONE'
+                m.state = 'DONE'
                 view_debug(m)
                 # Adjust r1 for overshoot from this point:
                 while m.dec_by(1, 15):
@@ -48,7 +47,7 @@ def test_state_vreg_duplicate():
                 while m.dec(0):
                     m.inc(1)
         else:
-            print("------------")
+            print('------------')
             view_debug(m)
             # swap 0d
             while m.dec(1):


### PR DESCRIPTION
in order to enable breaking out of nested loop blocks in 2 register Minsky machines. PMMN does not allow this and is therefore more akin to 2-cell bf when using only 2 registers.

This was an early attempt to work with 2 register machines -- now I believe it is possible without adding extra state like this branch tries to do.

Retaining as a record of the idea.